### PR TITLE
Update score display to retro font and position

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,27 +24,35 @@
             width: 100vw;
             height: 100vh;
         }
+        @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+        
         #score {
             position: absolute;
             top: 20px;
             left: 20px;
-            font-size: 24px;
+            font-size: 32px;
+            font-family: 'Press Start 2P', cursive;
             z-index: 100;
-            background-color: rgba(0, 0, 0, 0.5);
-            padding: 10px;
-            border-radius: 5px;
+            background-color: rgba(0, 0, 0, 0.7);
+            padding: 15px;
+            border-radius: 8px;
+            border: 2px solid #00ff00;
+            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
         }
         
         #high-score {
             position: absolute;
-            top: 20px;
-            right: 20px;
-            font-size: 24px;
+            top: 100px;
+            left: 20px;
+            font-size: 28px;
+            font-family: 'Press Start 2P', cursive;
             z-index: 100;
-            background-color: rgba(0, 0, 0, 0.5);
-            padding: 10px;
-            border-radius: 5px;
-            color: gold;
+            background-color: rgba(0, 0, 0, 0.7);
+            padding: 15px;
+            border-radius: 8px;
+            border: 2px solid #ffd700;
+            color: #ffd700;
+            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
         }
         
         #game-overlay {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update score and high score text styling to be retro, larger, and left-aligned.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses the user's request to make the score and high score text use a retro font, appear larger, and both be positioned on the left side of the screen. Additional styling (borders, shadows, padding, and background opacity) was added to enhance the retro arcade aesthetic.

---
<a href="https://cursor.com/background-agent?bcId=bc-400838c2-c00e-4a2a-a5cf-113b78f51b5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-400838c2-c00e-4a2a-a5cf-113b78f51b5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>