### PR TITLE
Manage snake color on powerup

### DIFF
--- a/graphics.js
+++ b/graphics.js
@@ -99,7 +99,15 @@ export class GraphicsEngine {
         );
         
         gameState.snake.forEach((segment, index) => {
-            const color = index === 0 ? 0x00ff00 : 0x44aa88; // Head is green, body is teal
+            // Change colors based on powerup state
+            let color;
+            if (gameState.powerUpActive) {
+                // Yellow colors when powerup is active
+                color = index === 0 ? 0xffff00 : 0xffdd00; // Head is bright yellow, body is darker yellow
+            } else {
+                // Original colors when powerup is not active
+                color = index === 0 ? 0x00ff00 : 0x44aa88; // Head is green, body is teal
+            }
             const material = new THREE.MeshPhongMaterial({ color });
             const cube = new THREE.Mesh(geometry, material);
             cube.position.copy(segment);


### PR DESCRIPTION
Change snake color to yellow when powerup is active to provide visual feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-79241a4f-2002-48e4-9eb6-4966ab0cb085">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79241a4f-2002-48e4-9eb6-4966ab0cb085">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>