### PR TITLE
feat(graphics): highlight snake during powerups

### DIFF
--- a/graphics.js
+++ b/graphics.js
@@ -99,7 +99,15 @@ export class GraphicsEngine {
         );
         
         gameState.snake.forEach((segment, index) => {
-            const color = index === 0 ? 0x00ff00 : 0x44aa88; // Head is green, body is teal
+            let color;
+            if (gameState.powerUpActive) {
+                // When the power-up is active the whole snake should be yellow
+                color = 0xffff00;
+            } else {
+                // Default colors: green head, teal body
+                color = index === 0 ? 0x00ff00 : 0x44aa88;
+            }
+
             const material = new THREE.MeshPhongMaterial({ color });
             const cube = new THREE.Mesh(geometry, material);
             cube.position.copy(segment);


### PR DESCRIPTION
## What Changed?
- changed `renderSnake` to use yellow color during active powerups

## Why Was This Change Made?
- to visually indicate when the player has collected a powerup

## How Was This Implemented?
- added logic in `graphics.js` to check `gameState.powerUpActive` and adjust snake segment colors accordingly

### Changed Files
- `graphics.js`


------
https://chatgpt.com/codex/tasks/task_b_6888b92084b0832f8a9f9931859966d4